### PR TITLE
Invoke the callback after it has been deregistered

### DIFF
--- a/src/AsyncTimer.cpp
+++ b/src/AsyncTimer.cpp
@@ -71,12 +71,13 @@ void AsyncTimer::handle() {
         m_callsArray[i].timestamp = timestamp;
         m_callsArray[i].callback();
       } else {
-        m_callsArray[i].callback();
+        void (*cb)() = m_callsArray[i].callback;
         m_callsArray[i].active = false;
         m_callsArray[i].callback = nullptr;
         m_arrayLength--;
         m_availableIndices[m_availableIndicesLength] = i;
         m_availableIndicesLength++;
+        cb();
       }
     }
   }


### PR DESCRIPTION
A callback might possibly call `.cancel()` for itself which will free the slot. Calling `setTimeout()` then will potentially register it on that just-freed slot. As the original callback completes and execution continues from line 75 the slot will then be freed and the new event will be lost. This must not happen!